### PR TITLE
Add missing deps and fix pep8

### DIFF
--- a/nfv_tempest_plugin/tests/common/shell_utilities.py
+++ b/nfv_tempest_plugin/tests/common/shell_utilities.py
@@ -251,7 +251,7 @@ def get_value_from_ini_config(overcloud_node, config_path,
     class M(OrderedDict):
         def __setitem__(self, key, value):
             v_val = self.get(key)
-            if v_val is not None and type(value) == list:
+            if v_val is not None and isinstance(value, list):
                 v_val.append(value[0])
             else:
                 v_val = value

--- a/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
+++ b/nfv_tempest_plugin/tests/scenario/baremetal_manager.py
@@ -457,7 +457,7 @@ class BareMetalManager(api_version_utils.BaseMicroversionTest,
             if 'pool_start' in net_param:
                 network_kwargs['allocation_pools'] = \
                     [{'start': net_param['pool_start'],
-                      'end':net_param['pool_end']}]
+                      'end': net_param['pool_end']}]
             if 'dns_nameservers' in net_param:
                 network_kwargs['dns_nameservers'] = \
                     net_param['dns_nameservers']

--- a/nfv_tempest_plugin/tests/scenario/test_igmp_snooping_usecases.py
+++ b/nfv_tempest_plugin/tests/scenario/test_igmp_snooping_usecases.py
@@ -84,7 +84,7 @@ class TestIgmpSnoopingScenarios(base_test.BaseTest):
 
                 for check in checks:
                     if check in diff_checks_cmd:
-                        if type(ovs_data_filt[check]) == str:
+                        if isinstance(ovs_data_filt[check], str):
                             # If object is not equal to 'true' or 'false'
                             # ValueError exception will be raised
                             ovs_data_filt[check] = \

--- a/nfv_tempest_plugin/tests/scenario/test_nfv_offload.py
+++ b/nfv_tempest_plugin/tests/scenario/test_nfv_offload.py
@@ -535,9 +535,9 @@ class TestNfvOffload(base_test.BaseTest):
 
     def test_offload_tcp_conntrack_transparent_vlan(
             self, test='offload_tcp_conntrack_transparent_vlan'):
-        """Check TCP traffic is offloaded in transparent vlan network with sec groups
+        """Check TCP traffic is offloaded in transparent vlan network
 
-        The following test deploy vms, on hw-offload computes.
+        with sec groups. The following test deploy vms, on hw-offload computes.
         Vms have security groups enabled.
         It sends Ttcp traffic and check conntrack table to check if flows
         are offloaded

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ python-novaclient==17.4.0
 metalsmith
 paramiko==2.11.0
 # openstack-tempest/requirements.txt:jsonschema>=3.2.0 # MIT
-# current version 4.0.0 is breaking aggregates client 
+# current version 4.0.0 is breaking aggregates client
 # validation
 jsonschema==3.2.0 # MIT
 cryptography==3.3.2
+tempest>=27.0.0 # Apache-2.0
+neutron_tempest_plugin>=0.9.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-minversion = 2.3.1
-envlist = py27,pep8
+minversion = 3.18.0
+envlist = py3,pep8
 skipsdist = True
 
 # info: to run individual tests/ testcase,
@@ -12,7 +12,10 @@ usedevelop = True
 setenv =
   VIRTUAL_ENV={envdir}
   PYTHONWARNINGS=default::DeprecationWarning
-deps = -r{toxinidir}/test-requirements.txt
+allowlist_externals = find
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands =
   # Cleanup cache files to avoid failures when running tox on developer env.
   find . -type f -name "*.pyc" -delete


### PR DESCRIPTION
The patch adds missing tempest and neutron-tempest-plugin deps
to the requirements.txt.
It also fixes several pep8 issues as well as issues in the tox.ini
