### PR TITLE
Fix cloud-init issues

### DIFF
--- a/nfv_tempest_plugin/tests/scenario/manager_utils.py
+++ b/nfv_tempest_plugin/tests/scenario/manager_utils.py
@@ -531,7 +531,7 @@ class ManagerMixin(object):
                              password: {passwd}
                              chpasswd: {{expire: False}}
                              ssh_pwauth: True
-                             disable_root: 0
+                             disable_root: false
                              '''.format(user=self.instance_user,
                                         passwd=self.instance_pass)
         repos_config = CONF.nfv_plugin_options.instance_repo
@@ -596,7 +596,7 @@ class ManagerMixin(object):
                     body += '''
                                - path: {file_dest}
                                  owner: root:root
-                                 permissions: 0755
+                                 permissions: '0755'
                                  encoding: base64
                                  content: |
                                      {file_content}

--- a/nfv_tempest_plugin/tests/scenario/tests_scripts/custom_net_config.py
+++ b/nfv_tempest_plugin/tests/scenario/tests_scripts/custom_net_config.py
@@ -101,8 +101,9 @@ def check_existing_interfaces():
 def get_ifcfg_files():
     """Get ifaces with configuration file"""
     files = os.listdir('/etc/sysconfig/network-scripts/')
-    ifaces = [file.replace('ifcfg-', '') for file in files if 'ifcfg' in file]
-    ifaces.remove('lo')
+    ifaces = [file.replace('ifcfg-', '') for file in files
+              if 'ifcfg' in file and 'lo' not in file
+              and 'readme' not in file]
     return ifaces
 
 
@@ -119,7 +120,7 @@ def verify_interfaces_config(ifaces, tag):
        file will be configured.
     """
     files = get_ifcfg_files()
-    if set(files) == set([nic.keys()[0] for nic in ifaces]):
+    if set(files) == set([list(nic)[0] for nic in ifaces]):
         return ifaces
     logger.info('Applying osp10 workaroud. Expected '
                 '{} network files, found {}'.format(len(ifaces),
@@ -305,7 +306,7 @@ def main():
     else:
         logger.info('Recreate network configuration')
         recreate_interfaces_config(args.nics_data_path, ifaces)
-    execute_shell_command('systemctl restart network')
+    execute_shell_command('systemctl restart NetworkManager')
     logger.info('Network configuration completed')
 
 


### PR DESCRIPTION
Sometimes during test_sriov_free_resource one of VMs was not accessible via it's FIP due to wrong routing config. This was a result of failing custom_net_config.py script. This patch applies the following changes that fix executing of the script and stabilize the test.

- Fixed ValueError: list.remove(x): x not in list where script was trying to remove a non-existing element. Replaced dict.remove() by extending list comprehension to skip irrelevant values for interface names.

- Fixed TypeError: 'dict_keys' object is not subscriptable where scipt tried to access index of dict_keys object. Replaced 'disc_keys' with 'list' that works as expected.

- Fixed network restart command. The script was using 'systemctl restart network' which was not available. Replaced by 'systemctl restart NetworkManager'

- Fixed cloud-init params that were causing 'Invalid schema' errors when cloud-init was executing 'sudo cloud-init schema --system'. Set 'permissions' to string and 'disable_root' to boolean value.